### PR TITLE
Update with new workflow plus an edit to a var

### DIFF
--- a/.github/workflows/byron-test-build.yml
+++ b/.github/workflows/byron-test-build.yml
@@ -1,0 +1,41 @@
+name: Build and Tag Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      
+jobs:
+  build-and-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ vars.JF_URL }}
+          JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}
+
+      - name: Build Tag and push Docker Image
+        env:
+          IMAGE_NAME: infomagnus.jfrog.io/byron-im-docker/jfrog-docker-example-image:${{ github.run_number }}
+        run: |
+          jf docker build -t $IMAGE_NAME .
+          jf docker push $IMAGE_NAME
+          
+      - name: Publish Build info With JFrog CLI
+        env:
+          # Generated and maintained by GitHub
+          JFROG_CLI_BUILD_NAME: jfrog-docker-build-example
+          # JFrog organization secret
+          JFROG_CLI_BUILD_NUMBER : ${{ github.run_number }}
+        run: |
+          # Export the build name and build nuber
+          # Collect environment variables for the build
+          jf rt build-collect-env
+          # Collect VCS details from git and add them to the build
+          jf rt build-add-git
+          # Publish build info
+          jf rt build-publish

--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -41,7 +41,7 @@ jobs:
 
           # [Mandatory]
           # JFrog platform URL
-          JF_URL: https://${{ vars.JF_URL }}/
+          JF_URL: ${{ vars.JF_URL }}/
 
           # [Mandatory if JF_USER and JF_PASSWORD are not provided]
           # JFrog access token with 'read' permissions on Xray service


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to add a new workflow for building and tagging Docker images, and a small modification to an existing workflow for Frogbot scanning and fixing.

New workflow addition:

* [`.github/workflows/byron-test-build.yml`](diffhunk://#diff-68b0756495fa2ea62ee2cceb198ecb8ca3493d1a655bf078e9c2bc8429002b4dR1-R41): Added a new workflow to build and tag Docker images using JFrog CLI. This workflow includes steps for checking out the code, setting up JFrog CLI, building and pushing the Docker image, and publishing build information with JFrog CLI.

Modification to existing workflow:

* [`.github/workflows/frogbot-scan-and-fix.yml`](diffhunk://#diff-8c09d2f0195479608b087329e6b70fe7b67fa64845c1643d338af483b723e241L44-R44): Modified the `JF_URL` environment variable to remove the redundant `https://` prefix.