### PR TITLE
Byron test the workflows

### DIFF
--- a/.github/workflows/byron-test-build.yml
+++ b/.github/workflows/byron-test-build.yml
@@ -1,4 +1,4 @@
-name: Build and Tag Docker Image
+name: Byron Build and Tag Docker Image
 
 on:
   push:

--- a/.github/workflows/frogbot-scan-and-fix.yml
+++ b/.github/workflows/frogbot-scan-and-fix.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jfrog/frogbot@7fad842cf6ba3d755c2eb86376cce066327b55d1
+      - uses: jfrog/frogbot@v2
         env:
           JF_URL: ${{ vars.JF_URL }}/
           JF_ACCESS_TOKEN: ${{ secrets.JF_ACCESS_TOKEN }}

--- a/.github/workflows/frogbot-scan-pr.yml
+++ b/.github/workflows/frogbot-scan-pr.yml
@@ -34,8 +34,8 @@ jobs:
       #  2. Some projects require creating a frogbot-config.yml file. Read more about it here - https://github.com/jfrog/frogbot/blob/master/docs/frogbot-config.md
 
       - uses: jfrog/frogbot@v2
-        with:
-          oidc-provider-name: "byron-juice-shop"
+        #with:
+        #  oidc-provider-name: "byron-juice-shop"
         env:
           JFROG_CLI_LOG_LEVEL: DEBUG
           # [Mandatory if the two conditions below are met]


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve the build and scanning processes. The key changes involve renaming a job, updating the version of a GitHub Action, and commenting out an unused configuration option.

Workflow updates:

* [`.github/workflows/byron-test-build.yml`](diffhunk://#diff-68b0756495fa2ea62ee2cceb198ecb8ca3493d1a655bf078e9c2bc8429002b4dL1-R1): Renamed the job from "Build and Tag Docker Image" to "Byron Build and Tag Docker Image."
* [`.github/workflows/frogbot-scan-and-fix.yml`](diffhunk://#diff-8c09d2f0195479608b087329e6b70fe7b67fa64845c1643d338af483b723e241L20-R20): Updated the `jfrog/frogbot` GitHub Action to use version `v2` instead of a specific commit hash.
* [`.github/workflows/frogbot-scan-pr.yml`](diffhunk://#diff-82c246a4141885c1bc6530d15ef3270436c91f7cc43bcd1caec3e012426e4ac9L37-R38): Commented out the `oidc-provider-name` configuration option for the `jfrog/frogbot` GitHub Action.